### PR TITLE
add python 3.12 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     keywords='speechrecognition asr voiceactivitydetection vad webrtc',
     ext_modules=[module],


### PR DESCRIPTION
I have at least one Windows user of ffsubsync on Python 3.12, and it seems this excellent wheel is not available there [[ref]](https://github.com/smacke/ffsubsync/issues/104#issuecomment-2212062162). I think all I need to do is add an entry for Python 3.12 in setup.py and it will go there with the next release.